### PR TITLE
nginxのアクセスログフォーマットをjson形式で出力する 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ vendor/
 portal/log
 portal/tmp
 
+/webapp/logs/*
+!/webapp/logs/.gitkeep
+
 ### Portal
 # Ignore bundler config.
 /portal/.bundle

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     volumes:
       - ./etc/nginx/conf.d:/etc/nginx/conf.d
       - ./public:/public
+      - ./logs/nginx:/var/log/nginx
     ports:
       - "80:80"
     links:

--- a/webapp/etc/nginx/conf.d/default.conf
+++ b/webapp/etc/nginx/conf.d/default.conf
@@ -1,5 +1,20 @@
+log_format json escape=json '{"time":"$time_iso8601",'
+        '"host":"$remote_addr",'
+        '"port":"$remote_port",'
+        '"method":"$request_method",'
+        '"uri":"$request_uri",'
+        '"status":"$status",'
+        '"body_bytes":"$body_bytes_sent",'
+        '"referer":"$http_referer",'
+        '"ua":"$http_user_agent",'
+        '"request_time":"$request_time",'
+        '"response_time":"$upstream_response_time"'
+    '}';
+
 server {
   listen 80;
+
+  access_log /var/log/nginx/access.log json;
 
   client_max_body_size 10m;
   root /public/;

--- a/webapp/etc/nginx/conf.d/default.conf
+++ b/webapp/etc/nginx/conf.d/default.conf
@@ -11,16 +11,40 @@ log_format json escape=json '{"time":"$time_iso8601",'
         '"response_time":"$upstream_response_time"'
     '}';
 
+# server {
+#   listen 80;
+# 
+#   access_log /var/log/nginx/access.log json;
+# 
+#   client_max_body_size 10m;
+#   root /public/;
+# 
+#   location / {
+#     proxy_set_header Host $host;
+#     proxy_pass http://app:8080;
+#   }
+# }
+
 server {
-  listen 80;
+    listen 80;
 
-  access_log /var/log/nginx/access.log json;
+    access_log /var/log/nginx/access.log json;
 
-  client_max_body_size 10m;
-  root /public/;
+    client_max_body_size 10m;
+    root /public;
 
-  location / {
-    proxy_set_header Host $host;
-    proxy_pass http://app:8080;
-  }
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    location ~ \.php {
+        #fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME /var/www/html/$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        fastcgi_pass app:9000;
+    }
 }
+

--- a/webapp/rotate.sh
+++ b/webapp/rotate.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker compose exec nginx mv /var/log/nginx/access.log /var/log/nginx/access.log.`date +%Y%m%d-%H%M%S`
+docker compose exec nginx /usr/sbin/nginx -s reopen
+


### PR DESCRIPTION
## やったこと

- alpコマンドでparseできるように、json形式でnginx logを出力する
- 計測するために nginx logs を host にマウントする
    - ログローテンション用のスクリプトを追加した
- nginx + php-fpm で動作するように conf いじった
    - php.conf.org の内容をコピーした